### PR TITLE
Fix: modify broken static file path

### DIFF
--- a/packages/headless-inspector/src/server.ts
+++ b/packages/headless-inspector/src/server.ts
@@ -103,7 +103,7 @@ export const runServer = (
   };
   const server = createServer(
     createApp((app) => {
-      app.use('/', express.static(path.resolve(__dirname, '../dist')));
+      app.use('/', express.static(path.resolve(__dirname, '../dist/umd')));
       app.get('/json', serveDevInfo);
       app.get('/json/list', serveDevInfo);
     }),


### PR DESCRIPTION
`@line/headless-inspector` serves the static file bundled as UMD placed in `/dist/umd`, but the current implementation serves `/dist`, not `/dist/umd`