### PR TITLE
feat: detect protocol according to x-forwarded-proto

### DIFF
--- a/packages/headless-inspector/src/server.ts
+++ b/packages/headless-inspector/src/server.ts
@@ -164,7 +164,8 @@ const onConnection = (socket: ws, req: http.IncomingMessage, ssl: boolean) => {
   }
   log(`connection from ${type}, id: ${hiId}`);
   if (type === 'client') {
-    const protocol = ssl ? 'wss' : 'ws';
+    const isSecure = req.headers['x-forwarded-proto'] === 'https';
+    const protocol = isSecure || ssl ? 'wss' : 'ws';
     const url = `devtools://devtools/bundled/inspector.html?${protocol}=${req.headers.host}/?hi_id=${hiId}`;
     console.log('DevTools URL: \x1b[36m%s\x1b[0m', `${url}`);
   }


### PR DESCRIPTION
Fixed #5

The protocol that is determined when LIFF Inspector Server gets started and the protocol to which the client connects may be different under a proxy network.

`LIFF App (client) <--- https ---> load balancer <--- http ---> LIFF Inspector Server`

Currently the protocol of the devtools URL shown in console is determined by how LIFF Inspector Server is started, which results in showing the inconsistent protocol.