### PR TITLE
Bump @line/liff to 2.27.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1400,283 +1400,307 @@
       }
     },
     "node_modules/@liff/extensions": {
-      "version": "2.19.0",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/extensions/-/extensions-2.27.2.tgz",
+      "integrity": "sha512-4wdg6TxtPXjwGjFYlTBdLtRNX4ILblPuqC92Fbk5Up/avkCnghMhtMLnid1EKctDnZlY+YODuLVQ5rj5DUdbEg==",
       "dev": true,
-      "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/add-to-home-screen": "2.19.0",
-        "@liff/check-availability": "2.19.0",
-        "@liff/consts": "2.19.0",
-        "@liff/get-advertising-id": "2.19.0",
-        "@liff/get-line-version": "2.19.0",
-        "@liff/get-os": "2.19.0",
-        "@liff/logger": "2.19.0",
-        "@liff/scan-code": "2.19.0",
-        "@liff/store": "2.19.0",
-        "@liff/util": "2.19.0"
+        "@liff/add-to-home-screen": "2.27.2",
+        "@liff/check-availability": "2.27.2",
+        "@liff/consts": "2.27.2",
+        "@liff/get-advertising-id": "2.27.2",
+        "@liff/get-line-version": "2.27.2",
+        "@liff/get-os": "2.27.2",
+        "@liff/logger": "2.27.2",
+        "@liff/scan-code": "2.27.2",
+        "@liff/store": "2.27.2",
+        "@liff/types": "2.27.2",
+        "@liff/util": "2.27.2"
       }
     },
     "node_modules/@liff/extensions/node_modules/@liff/add-to-home-screen": {
-      "version": "2.19.0",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/add-to-home-screen/-/add-to-home-screen-2.27.2.tgz",
+      "integrity": "sha512-A2wXvDJpxosX3tUfbB21MGiyaw+I0o9ic3U4kH5oE5QHWDNIEb5wn2Mb00K0WXj/LFcvr9MX2yAngx4m5wJqHg==",
       "dev": true,
-      "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/check-availability": "2.19.0",
-        "@liff/consts": "2.19.0",
-        "@liff/is-in-client": "2.19.0",
-        "@liff/is-sub-window": "2.19.0",
-        "@liff/native-bridge": "2.19.0",
-        "@liff/open-window": "2.19.0",
-        "@liff/util": "2.19.0"
+        "@liff/consts": "2.27.2",
+        "@liff/open-window": "2.27.2",
+        "@liff/types": "2.27.2",
+        "@liff/util": "2.27.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/extensions/node_modules/@liff/check-availability": {
-      "version": "2.19.0",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/check-availability/-/check-availability-2.27.2.tgz",
+      "integrity": "sha512-fe0kHvcsDv8P2LB4Xt9VEgd8vvl4odhcrtPgvABMPnIpp/aIhYT8hXFtNS4/wTXQmEMxXvaGdKKVLfODq2ovjQ==",
       "dev": true,
-      "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/get-version": "2.19.0",
-        "@liff/is-api-available": "2.19.0",
-        "@liff/util": "2.19.0"
+        "@liff/get-version": "2.27.2",
+        "@liff/is-api-available": "2.27.2",
+        "@liff/types": "2.27.2",
+        "@liff/util": "2.27.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/extensions/node_modules/@liff/consts": {
-      "version": "2.19.0",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/consts/-/consts-2.27.2.tgz",
+      "integrity": "sha512-2pgXC56YFSzbCuHk9pI1Cvyet/ACach/uvcsMIxK+N7R4jTdPAZIiA6XKWLxgPRmXIh0lNm4pRa0vb0tBtcvdQ==",
       "dev": true,
-      "license": "SEE LICENSE IN README.md",
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/extensions/node_modules/@liff/get-advertising-id": {
-      "version": "2.19.0",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/get-advertising-id/-/get-advertising-id-2.27.2.tgz",
+      "integrity": "sha512-fmDKxJjjnx697LtMGWy4f9hzl64BMgmSt6OWHcodfDvIukBbuiWrFtDun/gjBkMLOlo6S9/drJiXGj5ieJWxqg==",
       "dev": true,
-      "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/check-availability": "2.19.0",
-        "@liff/consts": "2.19.0",
-        "@liff/native-bridge": "2.19.0",
-        "@liff/util": "2.19.0"
+        "@liff/types": "2.27.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/extensions/node_modules/@liff/get-line-version": {
-      "version": "2.19.0",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/get-line-version/-/get-line-version-2.27.2.tgz",
+      "integrity": "sha512-kqkjsEcpAhsMk7XPRiy21Pl/FPO89rZxmOO8g9m2f/PY3gJm3qKikqcyLylpQueiHH/mjd53Hj3U/00iA8rR8w==",
       "dev": true,
-      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/use": "2.27.2"
+      },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/extensions/node_modules/@liff/get-os": {
-      "version": "2.19.0",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/get-os/-/get-os-2.27.2.tgz",
+      "integrity": "sha512-Ckms8cIHRslZzLehpM1SvyItEi5KwXt34PlEObp5OPNl4rmgZyWaCe7UOk3go1c1EhZTnP3sS5LQPiXvU93UhQ==",
       "dev": true,
-      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/use": "2.27.2"
+      },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/extensions/node_modules/@liff/get-version": {
-      "version": "2.19.0",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/get-version/-/get-version-2.27.2.tgz",
+      "integrity": "sha512-zBu3PkDVRKcMzSfmA9Mamz71rSz7kS6LLi2qzqNtXpwTI9vxxt6RHL3ovrxZLerlk4SKxwNcynlUOG4x0GmDgg==",
       "dev": true,
-      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/use": "2.27.2"
+      },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/extensions/node_modules/@liff/hooks": {
-      "version": "2.19.0",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/hooks/-/hooks-2.27.2.tgz",
+      "integrity": "sha512-6o7D+Y1EmfRp2Tc26CNEpiRsjKWUV1ILuXpzN1AYW4wQXu5hk7DAm4tA9rarR7dHxjpKEmMvqle/LrIEq1CDvA==",
       "dev": true,
-      "license": "SEE LICENSE IN README.md",
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/extensions/node_modules/@liff/is-api-available": {
-      "version": "2.19.0",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/is-api-available/-/is-api-available-2.27.2.tgz",
+      "integrity": "sha512-SDMtlWcR8vYwChzGQWJdCK07bWbA4eHRamipTdCVQKQU9lUHD4VOoTjIWEQ/P7n7egfdZlVYZMNJdsfrb8miqg==",
       "dev": true,
-      "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/consts": "2.19.0",
-        "@liff/get-line-version": "2.19.0",
-        "@liff/is-in-client": "2.19.0",
-        "@liff/is-logged-in": "2.19.0",
-        "@liff/store": "2.19.0",
-        "@liff/util": "2.19.0"
+        "@liff/consts": "2.27.2",
+        "@liff/get-line-version": "2.27.2",
+        "@liff/get-os": "2.27.2",
+        "@liff/is-in-client": "2.27.2",
+        "@liff/is-logged-in": "2.27.2",
+        "@liff/is-sub-window": "2.27.2",
+        "@liff/store": "2.27.2",
+        "@liff/use": "2.27.2",
+        "@liff/util": "2.27.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/extensions/node_modules/@liff/is-in-client": {
-      "version": "2.19.0",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/is-in-client/-/is-in-client-2.27.2.tgz",
+      "integrity": "sha512-KJ16of9tgULZUGC/bfKxJ7focgLTUEfyuxH7eElKwXcEmkrASn8j7P2HTJ8w+vAhRRKlDCQgkbNwVWQyzV7sNw==",
       "dev": true,
-      "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/consts": "2.19.0",
-        "@liff/util": "2.19.0"
+        "@liff/consts": "2.27.2",
+        "@liff/use": "2.27.2",
+        "@liff/util": "2.27.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/extensions/node_modules/@liff/is-logged-in": {
-      "version": "2.19.0",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/is-logged-in/-/is-logged-in-2.27.2.tgz",
+      "integrity": "sha512-lZdzM3yz+qXrYEWPBNC4+flAcX62yQb6kdcK48aIYlqZUha5PyQAENvyNWCmkGuz0MWwI+Ri23CZQJEVkPTaLA==",
       "dev": true,
-      "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/store": "2.19.0"
+        "@liff/store": "2.27.2",
+        "@liff/use": "2.27.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/extensions/node_modules/@liff/is-sub-window": {
-      "version": "2.19.0",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/is-sub-window/-/is-sub-window-2.27.2.tgz",
+      "integrity": "sha512-sn1GZ4eRX36DntBeSJMOYN5Afd1FoHykb3dUjByt9uCZajB7Q7ENfuGYbA5OB1Frpr/pzaOJeyrPeA4HB64UVw==",
       "dev": true,
-      "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/consts": "2.19.0",
-        "@liff/is-in-client": "2.19.0",
-        "@liff/store": "2.19.0",
-        "@liff/use": "2.19.0",
-        "@liff/util": "2.19.0"
+        "@liff/consts": "2.27.2",
+        "@liff/is-in-client": "2.27.2",
+        "@liff/store": "2.27.2",
+        "@liff/use": "2.27.2",
+        "@liff/util": "2.27.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/extensions/node_modules/@liff/logger": {
-      "version": "2.19.0",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/logger/-/logger-2.27.2.tgz",
+      "integrity": "sha512-3CiHI+Jfeb0oFIxaHzMKIGDwNAu1WwS1joGhqXs6X6TN5gIsJcXxiyXrDjaonl67+qHqv91ylinnmpffR57dbA==",
       "dev": true,
-      "license": "SEE LICENSE IN README.md",
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/extensions/node_modules/@liff/native-bridge": {
-      "version": "2.19.0",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/native-bridge/-/native-bridge-2.27.2.tgz",
+      "integrity": "sha512-iURKjwED4SPeCq98T2Ph5gOsqFIJ4eeVMMR0hZgT4CBT+rHqMgEaG0A6w5QO+Nl+lr1xSKE3NZOhp19xAQvxrQ==",
       "dev": true,
-      "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/consts": "2.19.0",
-        "@liff/logger": "2.19.0",
-        "@liff/store": "2.19.0",
-        "@liff/util": "2.19.0"
+        "@liff/consts": "2.27.2",
+        "@liff/logger": "2.27.2",
+        "@liff/store": "2.27.2",
+        "@liff/types": "2.27.2",
+        "@liff/util": "2.27.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/extensions/node_modules/@liff/open-window": {
-      "version": "2.19.0",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/open-window/-/open-window-2.27.2.tgz",
+      "integrity": "sha512-nAR/8VBtWKQpCQouMGCHjTlpPkF0FVMuBVzy+BKuuj4iySweK01rwbDz+1lF7C63JvXTjOzEGzmpDcPtSucz4w==",
       "dev": true,
-      "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/consts": "2.19.0",
-        "@liff/get-line-version": "2.19.0",
-        "@liff/get-os": "2.19.0",
-        "@liff/is-in-client": "2.19.0",
-        "@liff/native-bridge": "2.19.0",
-        "@liff/util": "2.19.0"
+        "@liff/consts": "2.27.2",
+        "@liff/get-line-version": "2.27.2",
+        "@liff/get-os": "2.27.2",
+        "@liff/is-in-client": "2.27.2",
+        "@liff/native-bridge": "2.27.2",
+        "@liff/types": "2.27.2",
+        "@liff/use": "2.27.2",
+        "@liff/util": "2.27.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/extensions/node_modules/@liff/scan-code": {
-      "version": "2.19.0",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/scan-code/-/scan-code-2.27.2.tgz",
+      "integrity": "sha512-S3sSNyAOUbiRThBNQEoRCgFQ05J9HNZI4eSP0c/JFU/20U14piKLh/PXFIwBVBEIibpTvNPS1FT6T/dsBUHHmg==",
       "dev": true,
-      "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/check-availability": "2.19.0",
-        "@liff/consts": "2.19.0",
-        "@liff/native-bridge": "2.19.0",
-        "@liff/util": "2.19.0"
+        "@liff/types": "2.27.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/extensions/node_modules/@liff/store": {
-      "version": "2.19.0",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/store/-/store-2.27.2.tgz",
+      "integrity": "sha512-uRxe8Z1gqU/E2M3kz1w3WobqSKQ8X+Wc91FxlmTAyDVPjSf7A47lfLk3A/Uvg0QfBrxBcWZmKRFXfw6cQAbvqg==",
       "dev": true,
-      "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/consts": "2.19.0",
-        "@liff/is-in-client": "2.19.0",
-        "@liff/types": "2.19.0",
-        "@liff/util": "2.19.0"
+        "@liff/consts": "2.27.2",
+        "@liff/is-in-client": "2.27.2",
+        "@liff/types": "2.27.2",
+        "@liff/use": "2.27.2",
+        "@liff/util": "2.27.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/extensions/node_modules/@liff/use": {
-      "version": "2.19.0",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/use/-/use-2.27.2.tgz",
+      "integrity": "sha512-AkXxL9cYeWPMw1+B/JBoYpppeAaMUIX6+yIxRZGIHw+i2K4Jr0S3Z3xu3yTvjAFRrGbRpArpv7V7NZEc1oqFNA==",
       "dev": true,
-      "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/hooks": "2.19.0",
-        "@liff/logger": "2.19.0"
+        "@liff/hooks": "2.27.2",
+        "@liff/logger": "2.27.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/extensions/node_modules/@liff/util": {
-      "version": "2.19.0",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/util/-/util-2.27.2.tgz",
+      "integrity": "sha512-ibYBscxGjNazouZ//cxp+oIBJLVOmKxI9/5glUISJY2z3nrz1J6bQF0jfZIsSwl3VMQZnO2xeK5P1f7McpF5yg==",
       "dev": true,
-      "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/consts": "2.19.0",
-        "@liff/logger": "2.19.0"
+        "@liff/consts": "2.27.2",
+        "@liff/logger": "2.27.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/extensions/node_modules/tslib": {
-      "version": "2.6.2",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD",
       "peer": true
     },
     "node_modules/@liff/types": {
-      "version": "2.19.0",
-      "dev": true,
-      "license": "SEE LICENSE IN README.md"
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/types/-/types-2.27.2.tgz",
+      "integrity": "sha512-5vqPTFn3nKe2lXlGglM7e6MpCLpna7PdgwkCr8N2vBDvie1W9R9xZLvFqE4YogVWxHSONpKQ4r82LHeLVafTOA==",
+      "dev": true
     },
     "node_modules/@line/bot-sdk": {
-      "version": "7.7.0",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@line/bot-sdk/-/bot-sdk-10.2.0.tgz",
+      "integrity": "sha512-UbYONriZspwEiLhHP+RODMHaXxdhkj35KWoRXP7ysSU8G+2QULvBIBRLo6dmjUgPD5CaTj881zghMMdOg5mVrg==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "@types/body-parser": "^1.19.2",
-        "@types/node": "^18.0.0",
-        "axios": "^1.0.0",
-        "body-parser": "^1.20.0",
-        "file-type": "^16.5.4",
-        "form-data": "^4.0.0"
+        "@types/node": "^22.0.0"
       },
       "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@line/bot-sdk/node_modules/@types/node": {
-      "version": "18.18.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "axios": "^1.7.4"
       }
     },
     "node_modules/@line/headless-inspector": {
@@ -1692,43 +1716,49 @@
       "link": true
     },
     "node_modules/@line/liff": {
-      "version": "2.19.0",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@line/liff/-/liff-2.27.2.tgz",
+      "integrity": "sha512-l03EMOa2Xahct1voTbik4zTp5yOcYivb5p4MQWwnRIYsoRcnwFHEhT7KwvX/JdtmZbL3wLfBENGtm0BAtA1t9w==",
       "dev": true,
-      "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/analytics": "2.19.0",
-        "@liff/close-window": "2.19.0",
-        "@liff/consts": "2.19.0",
-        "@liff/extensions": "2.19.0",
-        "@liff/get-friendship": "2.19.0",
-        "@liff/get-language": "2.19.0",
-        "@liff/get-line-version": "2.19.0",
-        "@liff/get-os": "2.19.0",
-        "@liff/get-profile": "2.19.0",
-        "@liff/get-version": "2.19.0",
-        "@liff/hooks": "2.19.0",
-        "@liff/init": "2.19.0",
-        "@liff/is-api-available": "2.19.0",
-        "@liff/is-in-client": "2.19.0",
-        "@liff/is-logged-in": "2.19.0",
-        "@liff/is-sub-window": "2.19.0",
-        "@liff/liff-types": "2.19.0",
-        "@liff/login": "2.19.0",
-        "@liff/logout": "2.19.0",
-        "@liff/native-bridge": "2.19.0",
-        "@liff/open-window": "2.19.0",
-        "@liff/permanent-link": "2.19.0",
-        "@liff/permission": "2.19.0",
-        "@liff/ready": "2.19.0",
-        "@liff/scan-code-v2": "2.19.0",
-        "@liff/send-messages": "2.19.0",
-        "@liff/server-api": "2.19.0",
-        "@liff/share-target-picker": "2.19.0",
-        "@liff/store": "2.19.0",
-        "@liff/sub-window": "2.19.0",
-        "@liff/use": "2.19.0",
-        "@liff/util": "2.19.0",
-        "promise-polyfill": "^8.1.3",
+        "@liff/analytics": "2.27.2",
+        "@liff/close-window": "2.27.2",
+        "@liff/consts": "2.27.2",
+        "@liff/core": "2.27.2",
+        "@liff/create-shortcut-on-home-screen": "2.27.2",
+        "@liff/extensions": "2.27.2",
+        "@liff/get-app-language": "2.27.2",
+        "@liff/get-friendship": "2.27.2",
+        "@liff/get-language": "2.27.2",
+        "@liff/get-line-version": "2.27.2",
+        "@liff/get-origins": "2.27.2",
+        "@liff/get-os": "2.27.2",
+        "@liff/get-profile": "2.27.2",
+        "@liff/get-version": "2.27.2",
+        "@liff/hooks": "2.27.2",
+        "@liff/i18n": "2.27.2",
+        "@liff/iap": "2.27.2",
+        "@liff/init": "2.27.2",
+        "@liff/is-api-available": "2.27.2",
+        "@liff/is-in-client": "2.27.2",
+        "@liff/is-logged-in": "2.27.2",
+        "@liff/is-sub-window": "2.27.2",
+        "@liff/liff-types": "2.27.2",
+        "@liff/login": "2.27.2",
+        "@liff/logout": "2.27.2",
+        "@liff/native-bridge": "2.27.2",
+        "@liff/open-window": "2.27.2",
+        "@liff/permanent-link": "2.27.2",
+        "@liff/permission": "2.27.2",
+        "@liff/ready": "2.27.2",
+        "@liff/scan-code-v2": "2.27.2",
+        "@liff/send-messages": "2.27.2",
+        "@liff/server-api": "2.27.2",
+        "@liff/share-target-picker": "2.27.2",
+        "@liff/store": "2.27.2",
+        "@liff/sub-window": "2.27.2",
+        "@liff/use": "2.27.2",
+        "@liff/util": "2.27.2",
         "tslib": "^2.3.0",
         "whatwg-fetch": "^3.0.0"
       }
@@ -1738,251 +1768,416 @@
       "link": true
     },
     "node_modules/@line/liff/node_modules/@liff/analytics": {
-      "version": "2.19.0",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/analytics/-/analytics-2.27.2.tgz",
+      "integrity": "sha512-oVhfpArnbB5+dHeqcJQyZJY9qGqtjwq2CZIaioo2m1OA7khkzhQI5lOGbNdqiwvD3ft5vIx7pxysb2i2ggBNMA==",
       "dev": true,
-      "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/consts": "2.19.0",
-        "@liff/get-profile": "2.19.0",
-        "@liff/get-version": "2.19.0",
-        "@liff/is-logged-in": "2.19.0",
-        "@liff/logger": "2.19.0",
-        "@liff/store": "2.19.0",
-        "@liff/types": "2.19.0",
-        "@liff/use": "2.19.0",
-        "@liff/util": "2.19.0"
+        "@liff/consts": "2.27.2",
+        "@liff/core": "2.27.2",
+        "@liff/get-profile": "2.27.2",
+        "@liff/get-version": "2.27.2",
+        "@liff/is-logged-in": "2.27.2",
+        "@liff/logger": "2.27.2",
+        "@liff/store": "2.27.2",
+        "@liff/types": "2.27.2",
+        "@liff/use": "2.27.2",
+        "@liff/util": "2.27.2"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@line/liff/node_modules/@liff/check-availability": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/check-availability/-/check-availability-2.27.2.tgz",
+      "integrity": "sha512-fe0kHvcsDv8P2LB4Xt9VEgd8vvl4odhcrtPgvABMPnIpp/aIhYT8hXFtNS4/wTXQmEMxXvaGdKKVLfODq2ovjQ==",
+      "dev": true,
+      "dependencies": {
+        "@liff/get-version": "2.27.2",
+        "@liff/is-api-available": "2.27.2",
+        "@liff/types": "2.27.2",
+        "@liff/util": "2.27.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@line/liff/node_modules/@liff/close-window": {
-      "version": "2.19.0",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/close-window/-/close-window-2.27.2.tgz",
+      "integrity": "sha512-j4B/YpNIFm9oIWzkHRN5jcNeE+7kMlMRIuX5EAMJFSihbkEXVdrNwFDbj+pJfY/0Su/WZv4gX+DS9bEl47V/vQ==",
       "dev": true,
-      "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/get-line-version": "2.19.0",
-        "@liff/get-os": "2.19.0",
-        "@liff/native-bridge": "2.19.0",
-        "@liff/util": "2.19.0"
+        "@liff/get-line-version": "2.27.2",
+        "@liff/get-os": "2.27.2",
+        "@liff/native-bridge": "2.27.2",
+        "@liff/types": "2.27.2",
+        "@liff/use": "2.27.2",
+        "@liff/util": "2.27.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@line/liff/node_modules/@liff/consts": {
-      "version": "2.19.0",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/consts/-/consts-2.27.2.tgz",
+      "integrity": "sha512-2pgXC56YFSzbCuHk9pI1Cvyet/ACach/uvcsMIxK+N7R4jTdPAZIiA6XKWLxgPRmXIh0lNm4pRa0vb0tBtcvdQ==",
       "dev": true,
-      "license": "SEE LICENSE IN README.md",
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@line/liff/node_modules/@liff/core": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/core/-/core-2.27.2.tgz",
+      "integrity": "sha512-Y+1M5dKMAOG7Pu49K3AxYtL7jwMg5DQKAndN3Zjwv1fMC2y9LSKl37VEtRx0GoHdBu+UudFxZ0An+Yia2YByug==",
+      "dev": true,
+      "dependencies": {
+        "@liff/get-version": "2.27.2",
+        "@liff/init": "2.27.2",
+        "@liff/native-bridge": "2.27.2",
+        "@liff/ready": "2.27.2",
+        "@liff/store": "2.27.2",
+        "@liff/use": "2.27.2"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@line/liff/node_modules/@liff/create-shortcut-on-home-screen": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/create-shortcut-on-home-screen/-/create-shortcut-on-home-screen-2.27.2.tgz",
+      "integrity": "sha512-8ZiYX0Lr0Mh8Pq/3KXgHiTm45Iw8v/VJU8UF36LaO+asQWFGTLIWa/QO1NVlfi5FKu+WuApfh8jEA/C4Hb8zQA==",
+      "dev": true,
+      "dependencies": {
+        "@liff/consts": "2.27.2",
+        "@liff/get-os": "2.27.2",
+        "@liff/is-api-available": "2.27.2",
+        "@liff/is-in-client": "2.27.2",
+        "@liff/open-window": "2.27.2",
+        "@liff/permanent-link": "2.27.2",
+        "@liff/server-api": "2.27.2",
+        "@liff/store": "2.27.2",
+        "@liff/use": "2.27.2",
+        "@liff/util": "2.27.2"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@line/liff/node_modules/@liff/get-app-language": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/get-app-language/-/get-app-language-2.27.2.tgz",
+      "integrity": "sha512-RI6Vh77Ui/qZtu+5qGKo94iO31bI1YqDvTw2wCMbZob1LiSFU44o4Ghz6F40SZxhHXHGnEJQBT36MRNNlLV4Mw==",
+      "dev": true,
+      "dependencies": {
+        "@liff/get-line-version": "2.27.2",
+        "@liff/get-os": "2.27.2",
+        "@liff/is-in-client": "2.27.2",
+        "@liff/use": "2.27.2",
+        "@liff/util": "2.27.2"
+      },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@line/liff/node_modules/@liff/get-friendship": {
-      "version": "2.19.0",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/get-friendship/-/get-friendship-2.27.2.tgz",
+      "integrity": "sha512-ODnwxWU0FlubALaknEM5iUHURFDAU+b/h5eY+B8cbW4DNB3Wbyc/uKP6Pm0FX68abPIkIbkxlZXkADguVeTIJQ==",
       "dev": true,
-      "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/server-api": "2.19.0"
+        "@liff/permission": "2.27.2",
+        "@liff/server-api": "2.27.2",
+        "@liff/use": "2.27.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@line/liff/node_modules/@liff/get-language": {
-      "version": "2.19.0",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/get-language/-/get-language-2.27.2.tgz",
+      "integrity": "sha512-vHnCMmlVrUu0EMVe0NBvJhq91ZT+htjI/nOAEolOpJYrs4ibq1nA2+oyCTEYdvv7A6GfOwAvwOZ9JIZ+5flY6A==",
       "dev": true,
-      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/use": "2.27.2"
+      },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@line/liff/node_modules/@liff/get-line-version": {
-      "version": "2.19.0",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/get-line-version/-/get-line-version-2.27.2.tgz",
+      "integrity": "sha512-kqkjsEcpAhsMk7XPRiy21Pl/FPO89rZxmOO8g9m2f/PY3gJm3qKikqcyLylpQueiHH/mjd53Hj3U/00iA8rR8w==",
       "dev": true,
-      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/use": "2.27.2"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@line/liff/node_modules/@liff/get-origins": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/get-origins/-/get-origins-2.27.2.tgz",
+      "integrity": "sha512-ACzTXBYSwSfmaQtKzvi8Jz0VbOeasiDT3ILwNRsmHwElHkjxNtr3VP5E/C3Kw5Jsz4d45l03fK4Ap7zNuYKtPA==",
+      "dev": true,
+      "dependencies": {
+        "@liff/use": "2.27.2"
+      },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@line/liff/node_modules/@liff/get-os": {
-      "version": "2.19.0",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/get-os/-/get-os-2.27.2.tgz",
+      "integrity": "sha512-Ckms8cIHRslZzLehpM1SvyItEi5KwXt34PlEObp5OPNl4rmgZyWaCe7UOk3go1c1EhZTnP3sS5LQPiXvU93UhQ==",
       "dev": true,
-      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/use": "2.27.2"
+      },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@line/liff/node_modules/@liff/get-profile": {
-      "version": "2.19.0",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/get-profile/-/get-profile-2.27.2.tgz",
+      "integrity": "sha512-24ASXGil2xuIdQ9kscil115XWgjcE74Bk0Or4JrKogY4BMTCTImm9cUHzN7a167WZjbQQg/lBLfYk7PSNEZElw==",
       "dev": true,
-      "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/server-api": "2.19.0"
+        "@liff/permission": "2.27.2",
+        "@liff/server-api": "2.27.2",
+        "@liff/use": "2.27.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@line/liff/node_modules/@liff/get-version": {
-      "version": "2.19.0",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/get-version/-/get-version-2.27.2.tgz",
+      "integrity": "sha512-zBu3PkDVRKcMzSfmA9Mamz71rSz7kS6LLi2qzqNtXpwTI9vxxt6RHL3ovrxZLerlk4SKxwNcynlUOG4x0GmDgg==",
       "dev": true,
-      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/use": "2.27.2"
+      },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@line/liff/node_modules/@liff/hooks": {
-      "version": "2.19.0",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/hooks/-/hooks-2.27.2.tgz",
+      "integrity": "sha512-6o7D+Y1EmfRp2Tc26CNEpiRsjKWUV1ILuXpzN1AYW4wQXu5hk7DAm4tA9rarR7dHxjpKEmMvqle/LrIEq1CDvA==",
       "dev": true,
-      "license": "SEE LICENSE IN README.md",
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@line/liff/node_modules/@liff/i18n": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/i18n/-/i18n-2.27.2.tgz",
+      "integrity": "sha512-sRNYCvVOHOkiDxD2473UFGDVEsp7ZCd6z/aYZFpz2xYLspMLfjSlJFwt1EzVkJed8NrIe9JCaF5N7oTzTOITiQ==",
+      "dev": true,
+      "dependencies": {
+        "@liff/consts": "2.27.2",
+        "@liff/server-api": "2.27.2",
+        "@liff/use": "2.27.2",
+        "@liff/util": "2.27.2"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@line/liff/node_modules/@liff/iap": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/iap/-/iap-2.27.2.tgz",
+      "integrity": "sha512-tPZAn0JuPc47C/DQYaNGNew5q864Nmq1cW6Z3imMh3PuyEDVtAzgc7I/GLEBKSm/KmtToWbgSrfr+vppZ9zekQ==",
+      "dev": true,
+      "dependencies": {
+        "@liff/consts": "2.27.2",
+        "@liff/is-api-available": "2.27.2",
+        "@liff/native-bridge": "2.27.2",
+        "@liff/use": "2.27.2",
+        "@liff/util": "2.27.2"
+      },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@line/liff/node_modules/@liff/init": {
-      "version": "2.19.0",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/init/-/init-2.27.2.tgz",
+      "integrity": "sha512-wPpx9yZYKrB+ge9/p/xZ5/ejrdfn8xm4WWCvYlBMlc2JyE5fuqcojC8vUsocRIWdUBSgI6JSCNSaGoSFGWy9ig==",
       "dev": true,
-      "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/consts": "2.19.0",
-        "@liff/extensions": "2.19.0",
-        "@liff/get-line-version": "2.19.0",
-        "@liff/get-os": "2.19.0",
-        "@liff/hooks": "2.19.0",
-        "@liff/is-api-available": "2.19.0",
-        "@liff/is-in-client": "2.19.0",
-        "@liff/is-logged-in": "2.19.0",
-        "@liff/is-sub-window": "2.19.0",
-        "@liff/logger": "2.19.0",
-        "@liff/login": "2.19.0",
-        "@liff/logout": "2.19.0",
-        "@liff/native-bridge": "2.19.0",
-        "@liff/ready": "2.19.0",
-        "@liff/server-api": "2.19.0",
-        "@liff/store": "2.19.0",
-        "@liff/sub-window": "2.19.0",
-        "@liff/types": "2.19.0",
-        "@liff/use": "2.19.0",
-        "@liff/util": "2.19.0"
+        "@liff/check-availability": "2.27.2",
+        "@liff/close-window": "2.27.2",
+        "@liff/consts": "2.27.2",
+        "@liff/extensions": "2.27.2",
+        "@liff/get-line-version": "2.27.2",
+        "@liff/get-os": "2.27.2",
+        "@liff/hooks": "2.27.2",
+        "@liff/i18n": "2.27.2",
+        "@liff/is-api-available": "2.27.2",
+        "@liff/is-in-client": "2.27.2",
+        "@liff/is-logged-in": "2.27.2",
+        "@liff/is-sub-window": "2.27.2",
+        "@liff/logger": "2.27.2",
+        "@liff/login": "2.27.2",
+        "@liff/logout": "2.27.2",
+        "@liff/message-bus": "2.27.2",
+        "@liff/native-bridge": "2.27.2",
+        "@liff/permanent-link": "2.27.2",
+        "@liff/ready": "2.27.2",
+        "@liff/server-api": "2.27.2",
+        "@liff/store": "2.27.2",
+        "@liff/sub-window": "2.27.2",
+        "@liff/types": "2.27.2",
+        "@liff/use": "2.27.2",
+        "@liff/util": "2.27.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@line/liff/node_modules/@liff/is-api-available": {
-      "version": "2.19.0",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/is-api-available/-/is-api-available-2.27.2.tgz",
+      "integrity": "sha512-SDMtlWcR8vYwChzGQWJdCK07bWbA4eHRamipTdCVQKQU9lUHD4VOoTjIWEQ/P7n7egfdZlVYZMNJdsfrb8miqg==",
       "dev": true,
-      "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/consts": "2.19.0",
-        "@liff/get-line-version": "2.19.0",
-        "@liff/is-in-client": "2.19.0",
-        "@liff/is-logged-in": "2.19.0",
-        "@liff/store": "2.19.0",
-        "@liff/util": "2.19.0"
+        "@liff/consts": "2.27.2",
+        "@liff/get-line-version": "2.27.2",
+        "@liff/get-os": "2.27.2",
+        "@liff/is-in-client": "2.27.2",
+        "@liff/is-logged-in": "2.27.2",
+        "@liff/is-sub-window": "2.27.2",
+        "@liff/store": "2.27.2",
+        "@liff/use": "2.27.2",
+        "@liff/util": "2.27.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@line/liff/node_modules/@liff/is-in-client": {
-      "version": "2.19.0",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/is-in-client/-/is-in-client-2.27.2.tgz",
+      "integrity": "sha512-KJ16of9tgULZUGC/bfKxJ7focgLTUEfyuxH7eElKwXcEmkrASn8j7P2HTJ8w+vAhRRKlDCQgkbNwVWQyzV7sNw==",
       "dev": true,
-      "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/consts": "2.19.0",
-        "@liff/util": "2.19.0"
+        "@liff/consts": "2.27.2",
+        "@liff/use": "2.27.2",
+        "@liff/util": "2.27.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@line/liff/node_modules/@liff/is-logged-in": {
-      "version": "2.19.0",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/is-logged-in/-/is-logged-in-2.27.2.tgz",
+      "integrity": "sha512-lZdzM3yz+qXrYEWPBNC4+flAcX62yQb6kdcK48aIYlqZUha5PyQAENvyNWCmkGuz0MWwI+Ri23CZQJEVkPTaLA==",
       "dev": true,
-      "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/store": "2.19.0"
+        "@liff/store": "2.27.2",
+        "@liff/use": "2.27.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@line/liff/node_modules/@liff/is-sub-window": {
-      "version": "2.19.0",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/is-sub-window/-/is-sub-window-2.27.2.tgz",
+      "integrity": "sha512-sn1GZ4eRX36DntBeSJMOYN5Afd1FoHykb3dUjByt9uCZajB7Q7ENfuGYbA5OB1Frpr/pzaOJeyrPeA4HB64UVw==",
       "dev": true,
-      "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/consts": "2.19.0",
-        "@liff/is-in-client": "2.19.0",
-        "@liff/store": "2.19.0",
-        "@liff/use": "2.19.0",
-        "@liff/util": "2.19.0"
+        "@liff/consts": "2.27.2",
+        "@liff/is-in-client": "2.27.2",
+        "@liff/store": "2.27.2",
+        "@liff/use": "2.27.2",
+        "@liff/util": "2.27.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@line/liff/node_modules/@liff/liff-types": {
-      "version": "2.19.0",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/liff-types/-/liff-types-2.27.2.tgz",
+      "integrity": "sha512-QrSrDFqOZBB06/h7/BNN6dzeB74bXB/0Y1xBkhd80NsshWQbVUnb8SzzXjpym9PdDdtcq5Vm+tA21++tHE3kgg==",
       "dev": true,
-      "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/analytics": "2.19.0",
-        "@liff/close-window": "2.19.0",
-        "@liff/get-friendship": "2.19.0",
-        "@liff/get-language": "2.19.0",
-        "@liff/get-line-version": "2.19.0",
-        "@liff/get-os": "2.19.0",
-        "@liff/get-profile": "2.19.0",
-        "@liff/get-version": "2.19.0",
-        "@liff/init": "2.19.0",
-        "@liff/is-api-available": "2.19.0",
-        "@liff/is-in-client": "2.19.0",
-        "@liff/is-logged-in": "2.19.0",
-        "@liff/is-sub-window": "2.19.0",
-        "@liff/login": "2.19.0",
-        "@liff/logout": "2.19.0",
-        "@liff/native-bridge": "2.19.0",
-        "@liff/open-window": "2.19.0",
-        "@liff/permanent-link": "2.19.0",
-        "@liff/permission": "2.19.0",
-        "@liff/ready": "2.19.0",
-        "@liff/scan-code-v2": "2.19.0",
-        "@liff/send-messages": "2.19.0",
-        "@liff/share-target-picker": "2.19.0",
-        "@liff/store": "2.19.0",
-        "@liff/sub-window": "2.19.0",
-        "@liff/use": "2.19.0"
+        "@liff/analytics": "2.27.2",
+        "@liff/close-window": "2.27.2",
+        "@liff/create-shortcut-on-home-screen": "2.27.2",
+        "@liff/get-app-language": "2.27.2",
+        "@liff/get-friendship": "2.27.2",
+        "@liff/get-language": "2.27.2",
+        "@liff/get-line-version": "2.27.2",
+        "@liff/get-origins": "2.27.2",
+        "@liff/get-os": "2.27.2",
+        "@liff/get-profile": "2.27.2",
+        "@liff/get-version": "2.27.2",
+        "@liff/i18n": "2.27.2",
+        "@liff/iap": "2.27.2",
+        "@liff/init": "2.27.2",
+        "@liff/is-api-available": "2.27.2",
+        "@liff/is-in-client": "2.27.2",
+        "@liff/is-logged-in": "2.27.2",
+        "@liff/is-sub-window": "2.27.2",
+        "@liff/login": "2.27.2",
+        "@liff/logout": "2.27.2",
+        "@liff/native-bridge": "2.27.2",
+        "@liff/open-window": "2.27.2",
+        "@liff/permanent-link": "2.27.2",
+        "@liff/permission": "2.27.2",
+        "@liff/ready": "2.27.2",
+        "@liff/scan-code-v2": "2.27.2",
+        "@liff/send-messages": "2.27.2",
+        "@liff/share-target-picker": "2.27.2",
+        "@liff/store": "2.27.2",
+        "@liff/sub-window": "2.27.2",
+        "@liff/use": "2.27.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@line/liff/node_modules/@liff/logger": {
-      "version": "2.19.0",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/logger/-/logger-2.27.2.tgz",
+      "integrity": "sha512-3CiHI+Jfeb0oFIxaHzMKIGDwNAu1WwS1joGhqXs6X6TN5gIsJcXxiyXrDjaonl67+qHqv91ylinnmpffR57dbA==",
       "dev": true,
-      "license": "SEE LICENSE IN README.md",
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@line/liff/node_modules/@liff/login": {
-      "version": "2.19.0",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/login/-/login-2.27.2.tgz",
+      "integrity": "sha512-q+4WFuhE7TEoCvG9ZEPVqke4FX1yUzqRMr5XpYW1KdIaw1G6IlpAGaHiEHsklnrK80QDqUhDbwtkU1aKMAdOtQ==",
       "dev": true,
-      "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/consts": "2.19.0",
-        "@liff/get-version": "2.19.0",
-        "@liff/hooks": "2.19.0",
-        "@liff/is-in-client": "2.19.0",
-        "@liff/is-sub-window": "2.19.0",
-        "@liff/logger": "2.19.0",
-        "@liff/server-api": "2.19.0",
-        "@liff/store": "2.19.0",
-        "@liff/use": "2.19.0",
-        "@liff/util": "2.19.0",
+        "@liff/consts": "2.27.2",
+        "@liff/get-version": "2.27.2",
+        "@liff/hooks": "2.27.2",
+        "@liff/is-in-client": "2.27.2",
+        "@liff/is-sub-window": "2.27.2",
+        "@liff/logger": "2.27.2",
+        "@liff/server-api": "2.27.2",
+        "@liff/store": "2.27.2",
+        "@liff/sub-window": "2.27.2",
+        "@liff/use": "2.27.2",
+        "@liff/util": "2.27.2",
         "tiny-sha256": "^1.0.2"
       },
       "peerDependencies": {
@@ -1990,230 +2185,271 @@
       }
     },
     "node_modules/@line/liff/node_modules/@liff/logout": {
-      "version": "2.19.0",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/logout/-/logout-2.27.2.tgz",
+      "integrity": "sha512-upzhK5kQBWhlCuluweY+gWzxGZDcTGnXHFmsQrv5yLYmo021gi3/8oedvr+p6isGwkYfZ7rGrsE4eKZw5bGeiw==",
       "dev": true,
-      "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/store": "2.19.0"
+        "@liff/store": "2.27.2",
+        "@liff/use": "2.27.2"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@line/liff/node_modules/@liff/message-bus": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/message-bus/-/message-bus-2.27.2.tgz",
+      "integrity": "sha512-I5B7vSfMEAW1FF2yPAQ8/hwroyHWjlkdpPJDbNh7B1vf6VYp1BgmEIOpeongEPlxgY30cpxozbDDnZ2yBneiMw==",
+      "dev": true,
+      "dependencies": {
+        "@liff/consts": "2.27.2",
+        "@liff/store": "2.27.2",
+        "@liff/util": "2.27.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@line/liff/node_modules/@liff/native-bridge": {
-      "version": "2.19.0",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/native-bridge/-/native-bridge-2.27.2.tgz",
+      "integrity": "sha512-iURKjwED4SPeCq98T2Ph5gOsqFIJ4eeVMMR0hZgT4CBT+rHqMgEaG0A6w5QO+Nl+lr1xSKE3NZOhp19xAQvxrQ==",
       "dev": true,
-      "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/consts": "2.19.0",
-        "@liff/logger": "2.19.0",
-        "@liff/store": "2.19.0",
-        "@liff/util": "2.19.0"
+        "@liff/consts": "2.27.2",
+        "@liff/logger": "2.27.2",
+        "@liff/store": "2.27.2",
+        "@liff/types": "2.27.2",
+        "@liff/util": "2.27.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@line/liff/node_modules/@liff/open-window": {
-      "version": "2.19.0",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/open-window/-/open-window-2.27.2.tgz",
+      "integrity": "sha512-nAR/8VBtWKQpCQouMGCHjTlpPkF0FVMuBVzy+BKuuj4iySweK01rwbDz+1lF7C63JvXTjOzEGzmpDcPtSucz4w==",
       "dev": true,
-      "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/consts": "2.19.0",
-        "@liff/get-line-version": "2.19.0",
-        "@liff/get-os": "2.19.0",
-        "@liff/is-in-client": "2.19.0",
-        "@liff/native-bridge": "2.19.0",
-        "@liff/util": "2.19.0"
+        "@liff/consts": "2.27.2",
+        "@liff/get-line-version": "2.27.2",
+        "@liff/get-os": "2.27.2",
+        "@liff/is-in-client": "2.27.2",
+        "@liff/native-bridge": "2.27.2",
+        "@liff/types": "2.27.2",
+        "@liff/use": "2.27.2",
+        "@liff/util": "2.27.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@line/liff/node_modules/@liff/permanent-link": {
-      "version": "2.19.0",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/permanent-link/-/permanent-link-2.27.2.tgz",
+      "integrity": "sha512-qSaEbs481HslEDNbewyalRASEYmNFg++wJbKo2M7AW/b29Y78v3a0gYa7PqW5m+FT7fJeN6tGQUgErYu6/+8FQ==",
       "dev": true,
-      "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/consts": "2.19.0",
-        "@liff/server-api": "2.19.0",
-        "@liff/store": "2.19.0",
-        "@liff/use": "2.19.0",
-        "@liff/util": "2.19.0"
+        "@liff/consts": "2.27.2",
+        "@liff/server-api": "2.27.2",
+        "@liff/store": "2.27.2",
+        "@liff/use": "2.27.2",
+        "@liff/util": "2.27.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@line/liff/node_modules/@liff/permission": {
-      "version": "2.19.0",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/permission/-/permission-2.27.2.tgz",
+      "integrity": "sha512-w310JPvVQ+KyBQNbWIDw5GY3hPOoo7VLABHRmi6+NIG7nH3s8yIFfFFDK29aeYNaN5+LR6kCuA8DSSOMQZgo+Q==",
       "dev": true,
-      "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/consts": "2.19.0",
-        "@liff/is-in-client": "2.19.0",
-        "@liff/server-api": "2.19.0",
-        "@liff/store": "2.19.0",
-        "@liff/sub-window": "2.19.0",
-        "@liff/use": "2.19.0",
-        "@liff/util": "2.19.0"
+        "@liff/consts": "2.27.2",
+        "@liff/is-api-available": "2.27.2",
+        "@liff/is-in-client": "2.27.2",
+        "@liff/server-api": "2.27.2",
+        "@liff/store": "2.27.2",
+        "@liff/sub-window": "2.27.2",
+        "@liff/use": "2.27.2",
+        "@liff/util": "2.27.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@line/liff/node_modules/@liff/ready": {
-      "version": "2.19.0",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/ready/-/ready-2.27.2.tgz",
+      "integrity": "sha512-vHNFOleicca6EuvW7CYgBH01DGhHBOQ4/M9TLzHUnCw6C1FwcUZsEQVsSJrnHfcT4+JNjtTtjGl6JvOc2RexgQ==",
       "dev": true,
-      "license": "SEE LICENSE IN README.md",
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@line/liff/node_modules/@liff/scan-code-v2": {
-      "version": "2.19.0",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/scan-code-v2/-/scan-code-v2-2.27.2.tgz",
+      "integrity": "sha512-dp3f3TJK+R3fCV20g4hzdiMtQP91xuv45v/WvRiHn4c8cowgMomOL6p6RX0mSnqil09KlLHrXRi7O80ZFST9Rg==",
       "dev": true,
-      "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/consts": "2.19.0",
-        "@liff/is-api-available": "2.19.0",
-        "@liff/sub-window": "2.19.0",
-        "@liff/use": "2.19.0",
-        "@liff/util": "2.19.0"
+        "@liff/consts": "2.27.2",
+        "@liff/is-api-available": "2.27.2",
+        "@liff/sub-window": "2.27.2",
+        "@liff/use": "2.27.2",
+        "@liff/util": "2.27.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@line/liff/node_modules/@liff/send-messages": {
-      "version": "2.19.0",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/send-messages/-/send-messages-2.27.2.tgz",
+      "integrity": "sha512-Ty2oyQKOoWZC3t+Pr5YscjynMOIKKScFstAFp8vzROrsLiZmWry8lvkELoxuUtjnx1izNxwkTc4chvcd/+pWkw==",
       "dev": true,
-      "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/consts": "2.19.0",
-        "@liff/get-line-version": "2.19.0",
-        "@liff/get-os": "2.19.0",
-        "@liff/server-api": "2.19.0",
-        "@liff/util": "2.19.0",
-        "@line/bot-sdk": "^7.0.0"
+        "@liff/consts": "2.27.2",
+        "@liff/get-line-version": "2.27.2",
+        "@liff/get-os": "2.27.2",
+        "@liff/permission": "2.27.2",
+        "@liff/server-api": "2.27.2",
+        "@liff/use": "2.27.2",
+        "@liff/util": "2.27.2",
+        "@line/bot-sdk": "^10.0.0"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@line/liff/node_modules/@liff/server-api": {
-      "version": "2.19.0",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/server-api/-/server-api-2.27.2.tgz",
+      "integrity": "sha512-cbZu0KY2zTIqQZFlv6Bjmp7r60+nN9b904BZSWG/Kx/9JvZmizrTXtNKTZg/7R1HLg/S3ctvjSIrZ5Bb6+QaYg==",
       "dev": true,
-      "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/consts": "2.19.0",
-        "@liff/store": "2.19.0",
-        "@liff/util": "2.19.0"
+        "@liff/consts": "2.27.2",
+        "@liff/store": "2.27.2",
+        "@liff/util": "2.27.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@line/liff/node_modules/@liff/share-target-picker": {
-      "version": "2.19.0",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/share-target-picker/-/share-target-picker-2.27.2.tgz",
+      "integrity": "sha512-1N7pQCHvCtQvm1KE2hwUjjL2VcztB5x6Y3EFNnj3Gi7p7JYaWBecmyTrmASsB3OYKANfOYg62ts1mJy/Jf/jmQ==",
       "dev": true,
-      "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/analytics": "2.19.0",
-        "@liff/consts": "2.19.0",
-        "@liff/get-line-version": "2.19.0",
-        "@liff/get-os": "2.19.0",
-        "@liff/is-in-client": "2.19.0",
-        "@liff/is-logged-in": "2.19.0",
-        "@liff/is-sub-window": "2.19.0",
-        "@liff/logger": "2.19.0",
-        "@liff/send-messages": "2.19.0",
-        "@liff/server-api": "2.19.0",
-        "@liff/store": "2.19.0",
-        "@liff/types": "2.19.0",
-        "@liff/use": "2.19.0",
-        "@liff/util": "2.19.0",
-        "@liff/window-postmessage": "2.19.0"
+        "@liff/analytics": "2.27.2",
+        "@liff/consts": "2.27.2",
+        "@liff/get-line-version": "2.27.2",
+        "@liff/get-os": "2.27.2",
+        "@liff/is-api-available": "2.27.2",
+        "@liff/is-in-client": "2.27.2",
+        "@liff/is-logged-in": "2.27.2",
+        "@liff/is-sub-window": "2.27.2",
+        "@liff/logger": "2.27.2",
+        "@liff/send-messages": "2.27.2",
+        "@liff/server-api": "2.27.2",
+        "@liff/store": "2.27.2",
+        "@liff/types": "2.27.2",
+        "@liff/use": "2.27.2",
+        "@liff/util": "2.27.2",
+        "@liff/window-postmessage": "2.27.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@line/liff/node_modules/@liff/store": {
-      "version": "2.19.0",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/store/-/store-2.27.2.tgz",
+      "integrity": "sha512-uRxe8Z1gqU/E2M3kz1w3WobqSKQ8X+Wc91FxlmTAyDVPjSf7A47lfLk3A/Uvg0QfBrxBcWZmKRFXfw6cQAbvqg==",
       "dev": true,
-      "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/consts": "2.19.0",
-        "@liff/is-in-client": "2.19.0",
-        "@liff/types": "2.19.0",
-        "@liff/util": "2.19.0"
+        "@liff/consts": "2.27.2",
+        "@liff/is-in-client": "2.27.2",
+        "@liff/types": "2.27.2",
+        "@liff/use": "2.27.2",
+        "@liff/util": "2.27.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@line/liff/node_modules/@liff/sub-window": {
-      "version": "2.19.0",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/sub-window/-/sub-window-2.27.2.tgz",
+      "integrity": "sha512-ofNIwvpBCkho/VPfk3y5Qlj7JB99MallqigvW04e4gucioei9ARQrjhnSMXpvv9+44pAlhNZOuEt/sySjAvWcQ==",
       "dev": true,
-      "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/close-window": "2.19.0",
-        "@liff/consts": "2.19.0",
-        "@liff/get-os": "2.19.0",
-        "@liff/is-api-available": "2.19.0",
-        "@liff/is-in-client": "2.19.0",
-        "@liff/is-sub-window": "2.19.0",
-        "@liff/logger": "2.19.0",
-        "@liff/server-api": "2.19.0",
-        "@liff/store": "2.19.0",
-        "@liff/util": "2.19.0"
+        "@liff/close-window": "2.27.2",
+        "@liff/consts": "2.27.2",
+        "@liff/get-os": "2.27.2",
+        "@liff/is-api-available": "2.27.2",
+        "@liff/is-in-client": "2.27.2",
+        "@liff/is-sub-window": "2.27.2",
+        "@liff/logger": "2.27.2",
+        "@liff/message-bus": "2.27.2",
+        "@liff/server-api": "2.27.2",
+        "@liff/store": "2.27.2",
+        "@liff/use": "2.27.2",
+        "@liff/util": "2.27.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@line/liff/node_modules/@liff/use": {
-      "version": "2.19.0",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/use/-/use-2.27.2.tgz",
+      "integrity": "sha512-AkXxL9cYeWPMw1+B/JBoYpppeAaMUIX6+yIxRZGIHw+i2K4Jr0S3Z3xu3yTvjAFRrGbRpArpv7V7NZEc1oqFNA==",
       "dev": true,
-      "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/hooks": "2.19.0",
-        "@liff/logger": "2.19.0"
+        "@liff/hooks": "2.27.2",
+        "@liff/logger": "2.27.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@line/liff/node_modules/@liff/util": {
-      "version": "2.19.0",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/util/-/util-2.27.2.tgz",
+      "integrity": "sha512-ibYBscxGjNazouZ//cxp+oIBJLVOmKxI9/5glUISJY2z3nrz1J6bQF0jfZIsSwl3VMQZnO2xeK5P1f7McpF5yg==",
       "dev": true,
-      "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/consts": "2.19.0",
-        "@liff/logger": "2.19.0"
+        "@liff/consts": "2.27.2",
+        "@liff/logger": "2.27.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@line/liff/node_modules/@liff/window-postmessage": {
-      "version": "2.19.0",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@liff/window-postmessage/-/window-postmessage-2.27.2.tgz",
+      "integrity": "sha512-IKJz0g201iUPFUv/eJopczKbGcOamM26dBb6L3hOw98NZtcQ4ZrPZc2c/Bl8M8fSoNavRe+iW7uVkM1O0K98xw==",
       "dev": true,
-      "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/consts": "2.19.0",
-        "@liff/logger": "2.19.0",
-        "@liff/util": "2.19.0"
+        "@liff/consts": "2.27.2",
+        "@liff/logger": "2.27.2",
+        "@liff/util": "2.27.2"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@line/liff/node_modules/tslib": {
-      "version": "2.6.2",
-      "dev": true,
-      "license": "0BSD"
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
@@ -2304,11 +2540,6 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
       }
-    },
-    "node_modules/@tokenizer/token": {
-      "version": "0.3.0",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
@@ -2472,10 +2703,11 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.9.1",
-      "license": "MIT",
+      "version": "22.18.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.6.tgz",
+      "integrity": "sha512-r8uszLPpeIWbNKtvWRt/DbVi5zbqZyj1PTmhRMqBMvDnaz1QpmSKujUtJLrqGZeoM8v72MfYggDceY4K1itzWQ==",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/qs": {
@@ -3335,16 +3567,20 @@
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true,
-      "license": "MIT"
+      "optional": true
     },
     "node_modules/axios": {
-      "version": "1.6.2",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "dev": true,
-      "license": "MIT",
+      "optional": true,
       "dependencies": {
-        "follow-redirects": "^1.15.0",
-        "form-data": "^4.0.0",
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -3734,8 +3970,10 @@
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "dev": true,
-      "license": "MIT",
+      "optional": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -3879,8 +4117,10 @@
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "dev": true,
-      "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -4067,6 +4307,22 @@
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4574,22 +4830,6 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
-    "node_modules/file-type": {
-      "version": "16.5.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "readable-web-to-node-stream": "^3.0.0",
-        "strtok3": "^6.2.4",
-        "token-types": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
-      }
-    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -4668,7 +4908,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.3",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
       "dev": true,
       "funding": [
         {
@@ -4676,7 +4918,7 @@
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
-      "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=4.0"
       },
@@ -4715,12 +4957,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.1",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "dev": true,
-      "license": "MIT",
+      "optional": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {
@@ -4967,6 +5213,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -5055,25 +5317,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.0",
@@ -7024,18 +7267,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/peek-readable": {
-      "version": "4.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "license": "ISC"
@@ -7115,11 +7346,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/promise-polyfill": {
-      "version": "8.3.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "license": "MIT",
@@ -7133,8 +7359,10 @@
     },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "dev": true,
-      "license": "MIT"
+      "optional": true
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -7226,34 +7454,6 @@
       "version": "17.0.2",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/readable-web-to-node-stream": {
-      "version": "3.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
     },
     "node_modules/rechoir": {
       "version": "0.8.0",
@@ -7689,14 +7889,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
     "node_modules/string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -7787,22 +7979,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/strtok3": {
-      "version": "6.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tokenizer/token": "^0.3.0",
-        "peek-readable": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/supports-color": {
@@ -7973,8 +8149,9 @@
     },
     "node_modules/tiny-sha256": {
       "version": "1.0.2",
-      "dev": true,
-      "license": "Public domain"
+      "resolved": "https://registry.npmjs.org/tiny-sha256/-/tiny-sha256-1.0.2.tgz",
+      "integrity": "sha512-IdsPtu8eJ0SwuCWUFm2euFH3jJvtpGQC0VpZNZlqxRvQ2zGvSjbXDO+4T8Rm5ETsmCQHHvKUGds69bJYrlb3Tg==",
+      "dev": true
     },
     "node_modules/tldts": {
       "version": "6.1.86",
@@ -8017,22 +8194,6 @@
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "engines": {
         "node": ">=0.6"
-      }
-    },
-    "node_modules/token-types": {
-      "version": "4.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tokenizer/token": "^0.3.0",
-        "ieee754": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/tough-cookie": {
@@ -8235,8 +8396,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "license": "MIT"
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
@@ -8313,11 +8475,6 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
@@ -8825,7 +8982,7 @@
         "liffInspector": "dist/local.js"
       },
       "devDependencies": {
-        "@line/liff": "2.19.0",
+        "@line/liff": "2.27.2",
         "@types/express": "4.17.21",
         "@types/ws": "8.5.12"
       }

--- a/packages/headless-inspector-core/src/interceptors/network/index.ts
+++ b/packages/headless-inspector-core/src/interceptors/network/index.ts
@@ -5,8 +5,6 @@ import { createXHRHandler } from './xhr';
 export const interceptNetwork = (emitter: InspectorEventEmitter): void => {
   if (window.fetch) {
     const handler = createFetchApiHandler(emitter);
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-expect-error
     window.fetch = new Proxy(window.fetch, handler);
   }
   if (window.XMLHttpRequest) {

--- a/packages/liff-inspector/package.json
+++ b/packages/liff-inspector/package.json
@@ -23,7 +23,7 @@
     "ws": "8.18.0"
   },
   "devDependencies": {
-    "@line/liff": "2.19.0",
+    "@line/liff": "2.27.2",
     "@types/express": "4.17.21",
     "@types/ws": "8.5.12"
   },


### PR DESCRIPTION
## Description
Upgrade @line/liff to v2.27.2 to address security vulnerabilities. (https://github.com/line/create-liff-app/security/dependabot/18)

This PR is a follow-up to https://github.com/line/liff-inspector/pull/27