### PR TITLE
Fix create-release-pr workflow

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,22 @@
+changelog:
+  exclude:
+    labels:
+      - 'type: question'
+      - 'type: discussion'
+      - 'type: release'
+
+  categories:
+    - title: 'Breaking Changes'
+      labels: ['type: breaking']
+    - title: 'New Features'
+      labels: ['type: feature']
+    - title: 'Bug Fixes'
+      labels: ['type: bug']
+    - title: 'Maintenance'
+      labels: ['type: maintenance']
+    - title: 'Documentation'
+      labels: ['type: documentation']
+    - title: 'Dependency Updates'
+      labels: ['type: dependencies']
+    - title: 'Other changes'
+      labels: ['*']

--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -1,6 +1,8 @@
 name: Check code health
 
-on: [pull_request]
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   build:

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -53,11 +53,38 @@ jobs:
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
-            const { data } = await github.rest.repos.generateReleaseNotes({
+            // --- Get latest release (previous tag) ---
+            let lastTag = "";
+            try {
+              const { data: latestRelease } = await github.rest.repos.getLatestRelease({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+              });
+              lastTag = latestRelease.tag_name;
+              core.info(`Previous release found: ${lastTag}`);
+            } catch (error) {
+              core.info("No previous release found — this will be the first release.");
+            }
+
+            // --- Get default branch ---
+            const { data: repoData } = await github.rest.repos.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              tag_name: `v${process.env.PACKAGE_VERSION}`
             });
+            const defaultBranch = repoData.default_branch;
+            core.info(`Default branch: ${defaultBranch}`);
+
+            // --- Generate release notes ---
+            const params = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: `v${process.env.PACKAGE_VERSION}`,
+              target_commitish: defaultBranch,
+            };
+            if (lastTag) {
+              params.previous_tag_name = lastTag;
+            }
+            const { data } = await github.rest.repos.generateReleaseNotes(params);
             core.setOutput('stdout', data.body);
         env:
           PACKAGE_VERSION: ${{ env.PACKAGE_VERSION }}

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -105,6 +105,7 @@ jobs:
           body: |
             ${{ steps.release_note.outputs.stdout }}
           labels: 'type: release'
+          draft: true
       - name: Check Pull Request
         run: |
           echo "Pull Request Number - ${STEPS_CPR_OUTPUTS_PULL_REQUEST_NUMBER}"


### PR DESCRIPTION
This PR fixes several issues found after testing the workflow introduced in the previous PR (https://github.com/line/liff-inspector/pull/31).

- PRs were not categorized by labels
→ Added a configuration file at `.github/release.yml`.
See: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes

- Generated release notes included all PRs in the repository instead of only those since the previous release
→ Added `previous_tag_name` and `target_commitish` parameters to the [generate-notes API](https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#generate-release-notes-content-for-a-release) call.

- Release PRs created by GitHub Actions could not be merged due to branch protection rules
→ Added the `ready_for_review` activity type to the build workflow trigger.
→ Release PRs are now created as draft PRs.
→ When maintainers mark the PR as Ready for review, the build workflow is automatically triggered and the PR becomes mergeable once checks pass.

### Note
Just Specifying
```
on: [pull_request]
```
means 
```
types: [opened, synchronize, reopened]
```
See https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request